### PR TITLE
HTML parse mode for class UnhealthyBackupWasFoundNotification

### DIFF
--- a/src/Notifications/Notifications/UnhealthyBackupWasFoundNotification.php
+++ b/src/Notifications/Notifications/UnhealthyBackupWasFoundNotification.php
@@ -17,6 +17,10 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
                 'exception' => $this->failure()->exception(),
                 'description' => $this->problemDescription(),
                 'properties' => $this->backupDestinationProperties(),
+            ])
+            ->options([
+                'parse_mode' => 'HTML',
+                'disable_web_page_preview' => true
             ]);
     }
 }


### PR DESCRIPTION
Fixed display telegram message for notification UnhealthyBackupWasFoundNotification  
before  
<img width="464" alt="Снимок экрана 2024-02-02 в 03 31 04" src="https://github.com/hotrush/laravel-backup-telegram-notifications/assets/45426321/a5fc1987-8e5a-4289-b662-3507e1b18e2a">


after  
<img width="482" alt="Снимок экрана 2024-02-02 в 03 31 55" src="https://github.com/hotrush/laravel-backup-telegram-notifications/assets/45426321/99253b95-9e31-4f29-a37d-2fc92126602e">


This branch can also be merged into master(v3)
